### PR TITLE
Fix race condition

### DIFF
--- a/webpush.go
+++ b/webpush.go
@@ -176,9 +176,11 @@ func SendNotificationWithContext(ctx context.Context, message []byte, s *Subscri
 	recordBuf.Write([]byte{byte(len(localPublicKey))})
 	recordBuf.Write(localPublicKey)
 
-	// Data
-	dataBuf := bytes.NewBuffer(message)
-
+	// Avoid data races by copying the message data
+	messageCopy := make([]byte, len(message))
+	copy(messageCopy, message)
+	dataBuf := bytes.NewBuffer(messageCopy)
+	
 	// Pad content to max record size - 16 - header
 	// Padding ending delimeter
 	dataBuf.Write([]byte("\x02"))


### PR DESCRIPTION
Hi,

thanks for maintaining this library!

I encountered a data race when sending the same message data to multiple clients concurrently. The reason is that ``bytes.NewBuffer(message)`` does not make a copy of the message slice; instead, each buffer points to the same underlying array, which can then be mutated by multiple goroutines in parallel.
This leads to non-deterministic bugs, and is especially problematic in typical broadcast scenarios.

Below is a race detector output (Go 1.22, ``-race``), showing the conflicting writes:

```
==================
WARNING: DATA RACE
Write at 0x00c00081c7c3 by goroutine 2717:
  runtime.slicecopy()
      /usr/lib/go/src/runtime/slice.go:355 +0x0
  bytes.(*Buffer).Write()
      /usr/lib/go/src/bytes/buffer.go:181 +0x118
  github.com/SherClockHolmes/webpush-go.SendNotificationWithContext()
      /home/xxx/go/pkg/mod/github.com/!sher!clock!holmes/webpush-go@v1.4.0/webpush.go:184 +0xc31
  github.com/SherClockHolmes/webpush-go.SendNotification()
      /home/xxx/go/pkg/mod/github.com/!sher!clock!holmes/webpush-go@v1.4.0/webpush.go:70 +0x239
  [...]

Previous write at 0x00c00081c7c3 by goroutine 2716:
  runtime.slicecopy()
      /usr/lib/go/src/runtime/slice.go:355 +0x0
  bytes.(*Buffer).Write()
      /usr/lib/go/src/bytes/buffer.go:181 +0x118
  github.com/SherClockHolmes/webpush-go.SendNotificationWithContext()
      /home/xxx/go/pkg/mod/github.com/!sher!clock!holmes/webpush-go@v1.4.0/webpush.go:184 +0xc31
  github.com/SherClockHolmes/webpush-go.SendNotification()
      /home/xxx/go/pkg/mod/github.com/!sher!clock!holmes/webpush-go@v1.4.0/webpush.go:70 +0x239
   [...]
```

This PR fixes the issue by copying the message buffer for each call, ensuring no shared underlying data between goroutines.
This adds a single allocation per notification, but eliminates the race and makes it safe to use ``SendNotification`` concurrently, even with identical payloads.

Please let me know if you have questions or would prefer a different approach.
Thanks again for your work on webpush-go!